### PR TITLE
Dennis Nehrenheim - Feed API Challenge

### DIFF
--- a/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
+++ b/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
@@ -19,6 +19,6 @@ public final class RemoteFeedLoader: FeedLoader {
 	}
 
 	public func load(completion: @escaping (FeedLoader.Result) -> Void) {
-		fatalError("Must be implemented")
+		client.get(from: url) { _ in }
 	}
 }

--- a/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
+++ b/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
@@ -19,6 +19,8 @@ public final class RemoteFeedLoader: FeedLoader {
 	}
 
 	public func load(completion: @escaping (FeedLoader.Result) -> Void) {
-		client.get(from: url) { _ in }
+		client.get(from: url) { result in
+			completion(.failure(Error.connectivity))
+		}
 	}
 }

--- a/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
+++ b/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
@@ -22,18 +22,18 @@ public final class RemoteFeedLoader: FeedLoader {
 		let items: [Image]
 
 		var feed: [FeedImage] {
-			return self.items.map { $0.item }
+			return self.items.map { $0.image }
 		}
 	}
 
 	private struct Image: Decodable {
-		let id: UUID
-		let description: String?
-		let location: String?
-		let image: URL
+		let image_id: UUID
+		let image_desc: String?
+		let image_loc: String?
+		let image_url: URL
 
-		var item: FeedImage {
-			return FeedImage(id: id, description: description, location: location, url: image)
+		var image: FeedImage {
+			return FeedImage(id: image_id, description: image_desc, location: image_loc, url: image_url)
 		}
 	}
 
@@ -44,11 +44,11 @@ public final class RemoteFeedLoader: FeedLoader {
 			switch result {
 			case let .success((data, response)):
 				guard response.statusCode == 200,
-					  let _ = try? JSONDecoder().decode(Root.self, from: data) else {
+				      let root = try? JSONDecoder().decode(Root.self, from: data) else {
 					completion(.failure(Error.invalidData))
 					return
 				}
-				completion(.success([]))
+				completion(.success(root.feed))
 
 			default:
 				completion(.failure(Error.connectivity))

--- a/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
+++ b/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
@@ -20,16 +20,20 @@ public final class RemoteFeedLoader: FeedLoader {
 
 	public func load(completion: @escaping (FeedLoader.Result) -> Void) {
 		client.get(from: url) { [weak self] result in
-			guard self != nil else { return }
+			guard let self = self else { return }
 
 			switch result {
 			case let .success((data, response)):
 				completion(FeedImagesMapper.map(data, from: response))
 
 			default:
-				completion(.failure(Error.connectivity))
+				completion(self.failure(.connectivity))
 			}
 		}
+	}
+
+	private func failure(_ error: RemoteFeedLoader.Error) -> FeedLoader.Result {
+		return .failure(error)
 	}
 }
 

--- a/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
+++ b/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
@@ -20,7 +20,13 @@ public final class RemoteFeedLoader: FeedLoader {
 
 	public func load(completion: @escaping (FeedLoader.Result) -> Void) {
 		client.get(from: url) { result in
-			completion(.failure(Error.connectivity))
+
+			switch result {
+			case let .success((_, response)) where response.statusCode != 200:
+				completion(.failure(Error.invalidData))
+			default:
+				completion(.failure(Error.connectivity))
+			}
 		}
 	}
 }

--- a/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
+++ b/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
@@ -19,11 +19,13 @@ public final class RemoteFeedLoader: FeedLoader {
 	}
 
 	public func load(completion: @escaping (FeedLoader.Result) -> Void) {
-		client.get(from: url) { result in
+		client.get(from: url) { [weak self] result in
+			guard self != nil else { return }
 
 			switch result {
-			case let .success((_, response)) where response.statusCode != 200:
+			case .success:
 				completion(.failure(Error.invalidData))
+
 			default:
 				completion(.failure(Error.connectivity))
 			}

--- a/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
+++ b/FeedAPIChallenge/Feed API/RemoteFeedLoader.swift
@@ -43,17 +43,13 @@ public final class RemoteFeedLoader: FeedLoader {
 
 			switch result {
 			case let .success((data, response)):
-				guard response.statusCode == 200 else {
+				guard response.statusCode == 200,
+					  let _ = try? JSONDecoder().decode(Root.self, from: data) else {
 					completion(.failure(Error.invalidData))
 					return
 				}
+				completion(.success([]))
 
-				do {
-					let _ = try JSONDecoder().decode(Root.self, from: data)
-					completion(.success([]))
-				} catch {
-					completion(.failure(Error.invalidData))
-				}
 			default:
 				completion(.failure(Error.connectivity))
 			}

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -24,16 +24,16 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		XCTAssertTrue(client.requestedURLs.isEmpty)
 	}
 
-//	func test_loadTwice_requestsDataFromURLTwice() {
-//		let url = URL(string: "https://a-given-url.com")!
-//		let (sut, client) = makeSUT(url: url)
-//
-//		sut.load { _ in }
-//		sut.load { _ in }
-//
-//		XCTAssertEqual(client.requestedURLs, [url, url])
-//	}
-//
+	func test_loadTwice_requestsDataFromURLTwice() {
+		let url = URL(string: "https://a-given-url.com")!
+		let (sut, client) = makeSUT(url: url)
+
+		sut.load { _ in }
+		sut.load { _ in }
+
+		XCTAssertEqual(client.requestedURLs, [url, url])
+	}
+
 //	func test_load_deliversConnectivityErrorOnClientError() {
 //		let (sut, client) = makeSUT()
 //

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -56,15 +56,15 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		}
 	}
 
-//	func test_load_deliversInvalidDataErrorOn200HTTPResponseWithInvalidJSON() {
-//		let (sut, client) = makeSUT()
-//
-//		expect(sut, toCompleteWith: .failure(.invalidData), when: {
-//			let invalidJSON = Data("invalid json".utf8)
-//			client.complete(withStatusCode: 200, data: invalidJSON)
-//		})
-//	}
-//
+	func test_load_deliversInvalidDataErrorOn200HTTPResponseWithInvalidJSON() {
+		let (sut, client) = makeSUT()
+
+		expect(sut, toCompleteWith: .failure(.invalidData), when: {
+			let invalidJSON = Data("invalid json".utf8)
+			client.complete(withStatusCode: 200, data: invalidJSON)
+		})
+	}
+
 //	func test_load_deliversInvalidDataErrorOn200HTTPResponseWithPartiallyValidJSONItems() {
 //		let (sut, client) = makeSUT()
 //

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -113,20 +113,19 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		})
 	}
 
-//
-//	func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
-//		let url = URL(string: "http://any-url.com")!
-//		let client = HTTPClientSpy()
-//		var sut: RemoteFeedLoader? = RemoteFeedLoader(url: url, client: client)
-//
-//		var capturedResults = [RemoteFeedLoader.Result]()
-//		sut?.load { capturedResults.append($0) }
-//
-//		sut = nil
-//		client.complete(withStatusCode: 200, data: makeItemsJSON([]))
-//
-//		XCTAssertTrue(capturedResults.isEmpty)
-//	}
+	func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
+		let url = URL(string: "http://any-url.com")!
+		let client = HTTPClientSpy()
+		var sut: RemoteFeedLoader? = RemoteFeedLoader(url: url, client: client)
+
+		var capturedResults = [RemoteFeedLoader.Result]()
+		sut?.load { capturedResults.append($0) }
+
+		sut = nil
+		client.complete(withStatusCode: 200, data: makeItemsJSON([]))
+
+		XCTAssertTrue(capturedResults.isEmpty)
+	}
 
 	// MARK: - Helpers
 

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -65,24 +65,24 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		})
 	}
 
-//	func test_load_deliversInvalidDataErrorOn200HTTPResponseWithPartiallyValidJSONItems() {
-//		let (sut, client) = makeSUT()
-//
-//		let validItem = makeItem(
-//			id: UUID(),
-//			imageURL: URL(string: "http://another-url.com")!
-//		).json
-//
-//		let invalidItem = ["invalid": "item"]
-//
-//		let items = [validItem, invalidItem]
-//
-//		expect(sut, toCompleteWith: .failure(.invalidData), when: {
-//			let json = makeItemsJSON(items)
-//			client.complete(withStatusCode: 200, data: json)
-//		})
-//	}
-//
+	func test_load_deliversInvalidDataErrorOn200HTTPResponseWithPartiallyValidJSONItems() {
+		let (sut, client) = makeSUT()
+
+		let validItem = makeItem(
+			id: UUID(),
+			imageURL: URL(string: "http://another-url.com")!
+		).json
+
+		let invalidItem = ["invalid": "item"]
+
+		let items = [validItem, invalidItem]
+
+		expect(sut, toCompleteWith: .failure(.invalidData), when: {
+			let json = makeItemsJSON(items)
+			client.complete(withStatusCode: 200, data: json)
+		})
+	}
+
 //	func test_load_deliversSuccessWithNoItemsOn200HTTPResponseWithEmptyJSONList() {
 //		let (sut, client) = makeSUT()
 //

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -83,15 +83,15 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		})
 	}
 
-//	func test_load_deliversSuccessWithNoItemsOn200HTTPResponseWithEmptyJSONList() {
-//		let (sut, client) = makeSUT()
-//
-//		expect(sut, toCompleteWith: .success([]), when: {
-//			let emptyListJSON = makeItemsJSON([])
-//			client.complete(withStatusCode: 200, data: emptyListJSON)
-//		})
-//	}
-//
+	func test_load_deliversSuccessWithNoItemsOn200HTTPResponseWithEmptyJSONList() {
+		let (sut, client) = makeSUT()
+
+		expect(sut, toCompleteWith: .success([]), when: {
+			let emptyListJSON = makeItemsJSON([])
+			client.complete(withStatusCode: 200, data: emptyListJSON)
+		})
+	}
+
 //	func test_load_deliversSuccessWithItemsOn200HTTPResponseWithJSONItems() {
 //		let (sut, client) = makeSUT()
 //

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -43,20 +43,19 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		})
 	}
 
-//
-//	func test_load_deliversInvalidDataErrorOnNon200HTTPResponse() {
-//		let (sut, client) = makeSUT()
-//
-//		let samples = [199, 201, 300, 400, 500]
-//
-//		samples.enumerated().forEach { index, code in
-//			expect(sut, toCompleteWith: .failure(.invalidData), when: {
-//				let json = makeItemsJSON([])
-//				client.complete(withStatusCode: code, data: json, at: index)
-//			})
-//		}
-//	}
-//
+	func test_load_deliversInvalidDataErrorOnNon200HTTPResponse() {
+		let (sut, client) = makeSUT()
+
+		let samples = [199, 201, 300, 400, 500]
+
+		samples.enumerated().forEach { index, code in
+			expect(sut, toCompleteWith: .failure(.invalidData), when: {
+				let json = makeItemsJSON([])
+				client.complete(withStatusCode: code, data: json, at: index)
+			})
+		}
+	}
+
 //	func test_load_deliversInvalidDataErrorOn200HTTPResponseWithInvalidJSON() {
 //		let (sut, client) = makeSUT()
 //

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -92,26 +92,27 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		})
 	}
 
-//	func test_load_deliversSuccessWithItemsOn200HTTPResponseWithJSONItems() {
-//		let (sut, client) = makeSUT()
-//
-//		let item1 = makeItem(
-//			id: UUID(),
-//			imageURL: URL(string: "http://a-url.com")!)
-//
-//		let item2 = makeItem(
-//			id: UUID(),
-//			description: "a description",
-//			location: "a location",
-//			imageURL: URL(string: "http://another-url.com")!)
-//
-//		let items = [item1.model, item2.model]
-//
-//		expect(sut, toCompleteWith: .success(items), when: {
-//			let json = makeItemsJSON([item1.json, item2.json])
-//			client.complete(withStatusCode: 200, data: json)
-//		})
-//	}
+	func test_load_deliversSuccessWithItemsOn200HTTPResponseWithJSONItems() {
+		let (sut, client) = makeSUT()
+
+		let item1 = makeItem(
+			id: UUID(),
+			imageURL: URL(string: "http://a-url.com")!)
+
+		let item2 = makeItem(
+			id: UUID(),
+			description: "a description",
+			location: "a location",
+			imageURL: URL(string: "http://another-url.com")!)
+
+		let items = [item1.model, item2.model]
+
+		expect(sut, toCompleteWith: .success(items), when: {
+			let json = makeItemsJSON([item1.json, item2.json])
+			client.complete(withStatusCode: 200, data: json)
+		})
+	}
+
 //
 //	func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
 //		let url = URL(string: "http://any-url.com")!

--- a/Tests/LoadFeedFromRemoteUseCaseTests.swift
+++ b/Tests/LoadFeedFromRemoteUseCaseTests.swift
@@ -34,14 +34,15 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
 		XCTAssertEqual(client.requestedURLs, [url, url])
 	}
 
-//	func test_load_deliversConnectivityErrorOnClientError() {
-//		let (sut, client) = makeSUT()
-//
-//		expect(sut, toCompleteWith: .failure(.connectivity), when: {
-//			let clientError = NSError(domain: "Test", code: 0)
-//			client.complete(with: clientError)
-//		})
-//	}
+	func test_load_deliversConnectivityErrorOnClientError() {
+		let (sut, client) = makeSUT()
+
+		expect(sut, toCompleteWith: .failure(.connectivity), when: {
+			let clientError = NSError(domain: "Test", code: 0)
+			client.complete(with: clientError)
+		})
+	}
+
 //
 //	func test_load_deliversInvalidDataErrorOnNon200HTTPResponse() {
 //		let (sut, client) = makeSUT()


### PR DESCRIPTION
- This PR implements the `RemoteFeedLoader` to load a collection of images from a backend.
- The `RemoteFeedLoader` conforms to the` <FeedLoader>` protocol creating an array of `FeedImage`.
- ![image](https://user-images.githubusercontent.com/19328249/117425455-17074280-af23-11eb-90f8-3eae1b85b73a.png)
- The `RemoteFeedLoader` follows the backend contract (Remote Feed Image Spec) below:

| Property      | Type                |
|---------------|---------------------|
| `image_id`    | `UUID`              |
| `image_desc`  | `String` (optional) |
| `image_loc`   | `String` (optional) |
| `image_url`	| `URL`               |